### PR TITLE
Fix FavoritesContext header comment

### DIFF
--- a/lib/context/FavoritesContext.tsx
+++ b/lib/context/FavoritesContext.tsx
@@ -1,4 +1,4 @@
-// lib/FavoritesContext.tsx
+// lib/context/FavoritesContext.tsx
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Character } from 'lib/services/RickAndMortyAPI';
 import React, { useState, useEffect, useContext, createContext } from 'react';


### PR DESCRIPTION
## Summary
- fix file header comment in `FavoritesContext` to match the file path

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6842d9441bdc83319838c7292baf1680