### PR TITLE
Remove deprecated splash property

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,7 +29,6 @@
       "image": "./assets/rick-and-morty-splash.jpg",
       "resizeMode": "cover",
       "backgroundColor": "#000000",
-      "imageResizeMode": "cover",
       "mdpi": "./assets/rick-and-morty-splash",
       "hdpi": "./assets/rick-and-morty-splash",
       "xhdpi": "./assets/rick-and-morty-splash",


### PR DESCRIPTION
## Summary
- clean up Expo config
- remove `imageResizeMode` from the splash config

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6842d93f4b40833196af2846d6bb2c3e