### PR TITLE
Fix favorite button color

### DIFF
--- a/components/FavoriteButton.tsx
+++ b/components/FavoriteButton.tsx
@@ -1,5 +1,6 @@
 import { FontAwesome } from '@expo/vector-icons';
 import { useFavorites } from 'lib/context/FavoritesContext';
+import { useTheme } from 'lib/context/ThemeContext';
 import { Character } from 'lib/services/RickAndMortyAPI';
 import { TouchableOpacity } from 'react-native';
 
@@ -11,6 +12,7 @@ export default function FavoriteButton({
   size?: number;
 }) {
   const { isFavorite, addFavorite, removeFavorite } = useFavorites();
+  const { theme } = useTheme();
 
   const handleFavoritePress = async () => {
     if (isFavorite(character.id)) {
@@ -28,7 +30,13 @@ export default function FavoriteButton({
       <FontAwesome
         name={isFavorite(character.id) ? 'heart' : 'heart-o'}
         size={size}
-        color={isFavorite(character.id) ? 'red' : 'black'}
+        color={
+          isFavorite(character.id)
+            ? 'red'
+            : theme === 'dark'
+              ? '#ffffff'
+              : '#000000'
+        }
       />
     </TouchableOpacity>
   );


### PR DESCRIPTION
## Summary
- adjust FavoriteButton icon color to match light/dark theme

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6841d654c0ec8331ad493a2da629c543