### PR TITLE
Add AGENTS.md and remove .workspace Project Notes from README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Working Context
+
+## Scope
+This file applies to the entire repository.
+
+## Default startup routine for Codex agents
+Before proposing changes or continuing implementation, read these files if they exist:
+
+1. `.workspace/PROJECT_CONTEXT.md`
+2. `.workspace/TODO.md`
+3. `.workspace/IDEAS.md`
+
+## Notes
+- These files provide maintainer context and priorities.
+- Do not require README mentions for this workflow.
+- If any of these files are missing, continue normally and state which one was not found.

--- a/README.md
+++ b/README.md
@@ -121,17 +121,6 @@ npm run lint
 npm run format
 ```
 
-## Project Notes
-
-This repository includes a local private workspace folder, `.workspace/`, used to keep:
-
-- project context
-- personal notes
-- APK files
-- references and work-in-progress material
-
-That folder is ignored by Git and is not intended to be part of the app itself.
-
 ## Roadmap Direction
 
 Planned and exploratory directions include:
@@ -146,4 +135,3 @@ Planned and exploratory directions include:
 ## Disclaimer
 
 This is a fan project inspired by Rick and Morty and is intended for learning, experimentation, and portfolio development.
-


### PR DESCRIPTION
### Motivation

- Introduce a repository-wide agent working context and default startup routine while removing a redundant `.workspace` Project Notes section from `README.md` to clarify where maintainers and agents should look for context.

### Description

- Add `AGENTS.md` with scope and a default startup routine that instructs agents to read `.workspace/PROJECT_CONTEXT.md`, `.workspace/TODO.md`, and `.workspace/IDEAS.md` before proposing changes, and remove the previous Project Notes block about the `.workspace` folder from `README.md`.

### Testing

- No automated tests were run because this change is documentation-only and does not affect runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb6bdf98248331b301de12a8291daf)